### PR TITLE
check for class existence

### DIFF
--- a/src/PageHelper.php
+++ b/src/PageHelper.php
@@ -41,8 +41,7 @@ class PageHelper implements TemplateGlobalProvider
         $filter = [];
         if ($strict) $filter['ClassName'] = $pageType;
 
-        $page = $pageType::get()->filter($filter);
-        if ($page && $page->exists()) return $page->first();
+        if (class_exists($pageType) && $page = $pageType::get()->filter($filter) && $page->exists()) return $page->first();
 
         return null;
     }


### PR DESCRIPTION
Should we implement the user_error or let it fail silently? Do you have a snippet for checking for live like we discussed here https://github.com/arillo/silverstripe-utils/issues/1?